### PR TITLE
Support web mention publish

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -22,6 +22,10 @@ import HeaderLink from "./HeaderLink.astro";
 		<HeaderLink href="/presentations"> Presentations </HeaderLink>
 		<HeaderLink href="/rss.xml">Feed</HeaderLink>
 	</nav>
+	<a href="https://brid.gy/publish/bluesky"></a>
+	<a href="https://brid.gy/publish/flickr"></a>
+	<a href="https://brid.gy/publish/github"></a>
+	<a href="https://brid.gy/publish/mastodon"></a>
 </footer>
 <style>
 	footer {


### PR DESCRIPTION
Working to enhance the POSSE workflow.

- adding links to bridgy to enable publishing via it's services.

> Your post HTML must also include that same target URL to verify your intent to publish.