### PR TITLE
fix: add formClass to homepage newsletter signup for proper gap spacing

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,6 +34,7 @@ const posts = (await getCollection("blog"))
 	<NewsletterSignup
 		title="Stay Updated"
 		description="Get notified when I publish new posts and share my latest thoughts."
+		formClass="form-inline"
 	/>
 </Layout>
 <style lang="scss">


### PR DESCRIPTION
## Summary
- Homepage newsletter form was missing `formClass="form-inline"` prop
- This caused the form to render as `display: block` with no gap between input and button
- Newsletter page worked correctly because it passes `formClass="form-inline"`

## Fix
Added `formClass="form-inline"` to the NewsletterSignup component on the homepage.

## Before/After
- **Before**: Form elements stacked vertically with no spacing (`gap: normal`)
- **After**: Form elements properly spaced (`gap: 12px` on desktop)

## Testing
Verified via Chrome DevTools that the homepage form now has:
- `display: flex`
- `gap: 12px` (or `.75rem`)